### PR TITLE
New feature: label inside the switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ new Vue({
             <td>A static label to always display whether on or off.</td>
         </tr>
         <tr>
+            <td>inlineLabel</td>
+            <td>Whether to show the labels (label or text-enabled/disabled) within the switch as opposed to above it.</td>
+        </tr>
+        <tr>
             <td>text-enabled</td>
             <td>The text that displays when enabled.</td>
         </tr>

--- a/dist/switches.css
+++ b/dist/switches.css
@@ -1,6 +1,6 @@
 /**
-                       * Default
-                       */
+* Default
+*/
 /**
  * Bulma
  */
@@ -20,7 +20,6 @@
     display: flex;
     align-items: center;
     font-size: 11px;
-    margin-bottom: 5px;
     margin: 0; }
     .vue-switcher__inlineLabel .vue_switcher__container {
       padding: 0;

--- a/dist/switches.css
+++ b/dist/switches.css
@@ -1,6 +1,6 @@
 /**
- * Default
- */
+                       * Default
+                       */
 /**
  * Bulma
  */
@@ -14,6 +14,31 @@
     display: block;
     font-size: 10px;
     margin-bottom: 5px; }
+  .vue-switcher__inlineLabel {
+    padding: 0 30px;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    font-size: 11px;
+    margin-bottom: 5px;
+    margin: 0; }
+    .vue-switcher__inlineLabel .vue_switcher__container {
+      padding: 0;
+      position: absolute;
+      left: 0;
+      top: 0px;
+      width: 100%;
+      display: flex;
+      height: 100%;
+      align-items: center;
+      justify-content: center; }
+      .vue-switcher__inlineLabel .vue_switcher__container span {
+        user-select: none; }
+    .vue-switcher__inlineLabel .vue_switcher__width-placeholder {
+      position: static;
+      visibility: hidden; }
+  .vue-switcher.vue-switcher--unchecked .vue-switcher__inlineLabel {
+    padding: 0 30px; }
   .vue-switcher input {
     opacity: 0;
     width: 100%;
@@ -22,8 +47,8 @@
     z-index: 1;
     cursor: pointer; }
   .vue-switcher div {
-    height: 15px;
-    width: 36px;
+    height: 10px;
+    width: 40px;
     position: relative;
     border-radius: 30px;
     display: -webkit-flex;
@@ -32,20 +57,19 @@
     align-items: center;
     justify-content: flex-start;
     cursor: pointer;
-    transition: linear .2s, background-color linear .2s; }
+    transition: all ease .4s; }
     .vue-switcher div:after {
       content: '';
-      height: 20px;
-      width: 20px;
+      height: 18px;
+      width: 18px;
       border-radius: 100px;
       display: block;
-      transition: linear .15s, background-color linear .15s;
+      transition: all ease .3s;
       position: absolute;
       left: 100%;
-      margin-left: -18px;
+      margin-left: -17px;
       cursor: pointer;
-      top: -3px;
-      box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.1); }
+      top: -4px; }
   .vue-switcher--unchecked div {
     justify-content: flex-end; }
     .vue-switcher--unchecked div:after {
@@ -59,10 +83,10 @@
     height: 26px;
     width: 51px; }
     .vue-switcher--bold div:after {
-      margin-left: -24px;
-      top: 3px; }
+      margin-left: -22px;
+      top: 4px; }
   .vue-switcher--bold--unchecked div:after {
-    left: 28px; }
+    left: 26px; }
   .vue-switcher--bold .vue-switcher__label span {
     padding-bottom: 7px;
     display: inline-block; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-switches",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "An on/off switch component for Vue.js with theme support.",
   "main": "src/switches.vue",
   "scripts": {

--- a/src/switches.scss
+++ b/src/switches.scss
@@ -1,6 +1,6 @@
-/**
- * Default
- */
+                     /**
+                       * Default
+                       */
 $color-default-default: #aaa;
 $color-default-green: #53b96e;
 $color-default-blue: #539bb9;
@@ -9,12 +9,12 @@ $color-default-orange: #b97953;
 $color-default-yellow: #bab353;
 
 $theme-default-colors: (
-    default : $color-default-default,
-    blue    : $color-default-blue,
-    red     : $color-default-red,
-    yellow  : $color-default-yellow,
-    orange  : $color-default-orange,
-    green   : $color-default-green
+  default : $color-default-default,
+  blue    : $color-default-blue,
+  red     : $color-default-red,
+  yellow  : $color-default-yellow,
+  orange  : $color-default-orange,
+  green   : $color-default-green
 );
 
 /**
@@ -28,12 +28,12 @@ $color-bulma-yellow: #ffdd57;
 $color-bulma-green: #22c65b;
 
 $theme-bulma-colors: (
-    default : $color-bulma-default,
-    primary : $color-bulma-primary,
-    blue    : $color-bulma-blue,
-    red     : $color-bulma-red,
-    yellow  : $color-bulma-yellow,
-    green   : $color-bulma-green
+  default : $color-bulma-default,
+  primary : $color-bulma-primary,
+  blue    : $color-bulma-blue,
+  red     : $color-bulma-red,
+  yellow  : $color-bulma-yellow,
+  green   : $color-bulma-green
 );
 
 /**
@@ -47,13 +47,14 @@ $color-bootstrap-warning: #f0ad4e;
 $color-bootstrap-danger: #c9302c;
 
 $theme-bootstrap-colors: (
-    default : $color-bootstrap-default,
-    primary : $color-bootstrap-primary,
-    success : $color-bootstrap-success,
-    info    : $color-bootstrap-info,
-    warning : $color-bootstrap-warning,
-    danger  : $color-bootstrap-danger
+  default : $color-bootstrap-default,
+  primary : $color-bootstrap-primary,
+  success : $color-bootstrap-success,
+  info    : $color-bootstrap-info,
+  warning : $color-bootstrap-warning,
+  danger  : $color-bootstrap-danger
 );
+
 
 .vue-switcher {
     position: relative;
@@ -63,6 +64,53 @@ $theme-bootstrap-colors: (
         display: block;
         font-size: 10px;
         margin-bottom: 5px;
+    }
+
+    $inlineLabelMargin: 30px;
+
+
+    &__inlineLabel {
+        padding: 0 $inlineLabelMargin ;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        font-size: 11px;
+        margin-bottom: 5px;
+        margin: 0;
+
+        .vue_switcher__container {
+            padding: 0;
+            position: absolute;
+            left: 0;
+            top: 0px;
+            width:  100% ;
+            display: flex;
+            height: 100%;
+            align-items: center;
+            justify-content: center;
+
+
+            span {
+                user-select: none;
+            }
+        }
+
+        .vue_switcher__width-placeholder {
+            position: static;
+            visibility: hidden;
+        }
+
+        // display: none;
+    }
+
+
+    &.vue-switcher--unchecked {
+        .vue-switcher__inlineLabel {
+            padding: 0 $inlineLabelMargin;
+
+            .vue_switcher__container {
+            }
+        }
     }
 
     input {
@@ -75,8 +123,8 @@ $theme-bootstrap-colors: (
     }
 
     div {
-        height: 15px;
-        width: 36px;
+        height: 10px;
+        width: 40px;
         position: relative;
         border-radius: 30px;
         display: -webkit-flex;
@@ -85,21 +133,20 @@ $theme-bootstrap-colors: (
         align-items: center;
         justify-content: flex-start;
         cursor: pointer;
-        transition: linear .2s, background-color linear .2s;
+        transition: all ease .4s;
 
         &:after {
             content: '';
-            height: 20px;
-            width: 20px;
+            height: 18px;
+            width: 18px;
             border-radius: 100px;
             display: block;
-            transition: linear .15s, background-color linear .15s;
+            transition: all ease .3s;
             position: absolute;
             left: 100%;
-            margin-left: -18px;
+            margin-left: -17px;
             cursor: pointer;
-            top: -3px;
-            box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.1);
+            top: -4px;
         }
     }
 
@@ -130,15 +177,15 @@ $theme-bootstrap-colors: (
             width: 51px;
 
             &:after {
-                margin-left: -24px;
-                top: 3px;
+                margin-left: -22px;
+                top: 4px;
             }
         }
 
         &--unchecked {
             div {
                 &:after {
-                    left: 28px;
+                    left: 26px;
                 }
             }
         }

--- a/src/switches.scss
+++ b/src/switches.scss
@@ -1,6 +1,6 @@
-                     /**
-                       * Default
-                       */
+/**
+* Default
+*/
 $color-default-default: #aaa;
 $color-default-green: #53b96e;
 $color-default-blue: #539bb9;
@@ -75,7 +75,6 @@ $theme-bootstrap-colors: (
         display: flex;
         align-items: center;
         font-size: 11px;
-        margin-bottom: 5px;
         margin: 0;
 
         .vue_switcher__container {

--- a/src/switches.vue
+++ b/src/switches.vue
@@ -1,6 +1,6 @@
 <template>
     <label :class="classObject">
-        <span class="vue-switcher__label" v-if="shouldShowLabel">
+        <span class="vue-switcher__label" v-if="shouldShowLabel && ! inlineLabel">
             <span v-if="label" v-text="label"></span>
             <span v-if="!label && value" v-text="textEnabled"></span>
             <span v-if="!label && !value" v-text="textDisabled"></span>
@@ -8,87 +8,112 @@
 
         <input type="checkbox" :disabled="disabled" @change="trigger" :checked="value">
 
-        <div></div>
+        <div><span class="vue-switcher__inlineLabel" v-if="shouldShowLabel && inlineLabel">
+            <span v-if="label" v-text="label" class="vue_switcher__container"><span v-text="label"></span></span>
+            <span v-if="!label && value" v-visible="value" class="vue_switcher__container"><span  v-text="textEnabled"></span></span>
+            <span v-if="!label && !value" v-visible="!value" class="vue_switcher__container"><span v-text="textDisabled"></span></span>
+            <span class="vue_switcher__width-placeholder" v-text="longestText"></span>
+        </span></div>
     </label>
 </template>
 
 <script>
 
-export default {
+  export default {
     name: 'switches',
 
     props: {
-        typeBold: {
-            default: false
-        },
+      typeBold: {
+        default: false
+      },
 
-        value: {
-            default: false
-        },
+      value: {
+        default: false
+      },
 
-        disabled: {
-            default: false
-        },
+      disabled: {
+        default: false
+      },
 
-        label: {
-            default: ''
-        },
+      label: {
+        default: ''
+      },
 
-        textEnabled: {
-            default: ''
-        },
+      inlineLabel: {
+        default: false
+      },
 
-        textDisabled: {
-            default: ''
-        },
+      textEnabled: {
+        default: ''
+      },
 
-        color: {
-            default: 'default'
-        },
+      textDisabled: {
+        default: ''
+      },
 
-        theme: {
-            default: 'default'
-        },
+      color: {
+        default: 'default'
+      },
 
-        emitOnMount: {
-            default: true
-        }
+      theme: {
+        default: 'default'
+      },
+
+      emitOnMount: {
+        default: true
+      }
     },
 
     mounted () {
-        if(this.emitOnMount) {
-            this.$emit('input', this.value)
-        }
+      if(this.emitOnMount) {
+        this.$emit('input', this.value)
+      }
     },
 
     methods: {
-        trigger (e) {
-            this.$emit('input', e.target.checked)
-        }
+      trigger (e) {
+        this.$emit('input', e.target.checked)
+      }
     },
 
     computed: {
-        classObject () {
+      longestText () {
+        return this.label || this.textEnabled.length > this.textDisabled.length ? this.textEnabled : this.textDisabled
+      },
+      classObject () {
 
-            const { color, value, theme, typeBold, disabled } = this;
+        const { color, value, theme, typeBold, disabled } = this;
 
-            return {
-                'vue-switcher' : true,
-                ['vue-switcher--unchecked'] : !value,
-                ['vue-switcher--disabled'] : disabled,
-                ['vue-switcher--bold']: typeBold,
-                ['vue-switcher--bold--unchecked']: typeBold && !value,
-                [`vue-switcher-theme--${theme}`] : color,
-                [`vue-switcher-color--${color}`] : color,
-            };
+        return {
+          'vue-switcher' : true,
+          ['vue-switcher--unchecked'] : !value,
+          ['vue-switcher--disabled'] : disabled,
+          ['vue-switcher--bold']: typeBold,
+          ['vue-switcher--bold--unchecked']: typeBold && !value,
+          [`vue-switcher-theme--${theme}`] : color,
+          [`vue-switcher-color--${color}`] : color,
+        };
 
-        },
+      },
 
-        shouldShowLabel () {
-            return this.label !== '' || this.textEnabled !== '' || this.textDisabled !== '';
+      shouldShowLabel () {
+        return this.label !== '' || this.textEnabled !== '' || this.textDisabled !== '';
+      }
+    },
+    directives: {
+      visible: {
+        update: (el, binding) => {
+          var value = binding.value;
+
+          if (!!value) {
+            el.style.visibility = 'visible';
+          } else {
+            el.style.visibility = 'hidden';
+          }
         }
+      }
     }
-}
+  }
 
 </script>
 


### PR DESCRIPTION
Hi, since I needed it for a project I've added the option for putting the label inside the switch. Label is centered and the width of the label is based on the longer text that needs to fit the container, using a hidden text (a fairly crude method, but I couldn't think of a better one!). 

If you like it, considering pulling the change. If you would like to receive screenshots, let me know.